### PR TITLE
Use 'docker_login' instead of 'shell'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The ansible tasks in this repo are intended to help with the task of mirroring i
 This playbook has only been tested on Fedora. It may or may not work on other Linux distributions. CentOS 7 is known not to work because the python-jinja2 package is too old. It may be possible to circumvent this by installing a newer version using pip, but this is generally inadvisable because it can cause problems wtih dnf/yum updates.
 
 * Install python3-openshift, jq, bsdtar, ansible, and moby-engine or docker-ce. For Fedora:
-  * `sudo dnf -y install python3-openshift jq bsdtar ansible moby-engine`
+  * `sudo dnf -y install python3-openshift python3-docker jq bsdtar ansible moby-engine`
   * `sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"` and reboot.
   * `sudo systemctl enable docker && sudo systemctl start docker`
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This playbook has only been tested on Fedora. It may or may not work on other Li
 
 * Login to registry.redhat.io
   * These are the same credentials you log into https://access.redhat.com
-  * `docker login -u $username` and enter your password when prompted.
+  * `docker login -u $username https://registry.redhat.io` and enter your password when prompted.
 
 * Ensure you are logged into your cluster
   * With Openshift 4 a kubeconfig file is created. You can export this in your `.bashrc` or elsewhere

--- a/roles/olm_disconnected/tasks/main.yml
+++ b/roles/olm_disconnected/tasks/main.yml
@@ -52,13 +52,21 @@
 
   - block:
     - name: Docker login to internal OpenShift registry
-      shell: docker login {{ registry_route.stdout }}  -u registry -p {{ registry_sa_token.stdout }}
+#      shell: docker login {{ registry_route.stdout }}  -u registry -p {{ registry_sa_token.stdout }}
+      docker_login:
+        username: registry
+        password: "{{ registry_sa_token.stdout }}"
+        registry: "{{ registry_route.stdout }}"
     rescue:
     - pause:
         prompt: Add {{ registry_route.stdout }} to your insecure regisries, restart docker, then press return to try again
 
     - name: Docker login to internal OpenShift registry
-      shell: docker login {{ registry_route.stdout }}  -u registry -p {{ registry_sa_token.stdout }}
+#      shell: docker login {{ registry_route.stdout }}  -u registry -p {{ registry_sa_token.stdout }}
+      docker_login:
+        username: registry
+        password: "{{ registry_sa_token.stdout }}"
+        registry: "{{ registry_route.stdout }}"
 
   - name: Add local_registry_ns permissions
     shell: oc policy add-role-to-group system:image-puller system:serviceaccounts:{{ deployment_namespace }} --namespace={{ local_registry_ns }}

--- a/roles/olm_disconnected/tasks/main.yml
+++ b/roles/olm_disconnected/tasks/main.yml
@@ -52,7 +52,6 @@
 
   - block:
     - name: Docker login to internal OpenShift registry
-#      shell: docker login {{ registry_route.stdout }}  -u registry -p {{ registry_sa_token.stdout }}
       docker_login:
         username: registry
         password: "{{ registry_sa_token.stdout }}"
@@ -62,7 +61,6 @@
         prompt: Add {{ registry_route.stdout }} to your insecure regisries, restart docker, then press return to try again
 
     - name: Docker login to internal OpenShift registry
-#      shell: docker login {{ registry_route.stdout }}  -u registry -p {{ registry_sa_token.stdout }}
       docker_login:
         username: registry
         password: "{{ registry_sa_token.stdout }}"


### PR DESCRIPTION
This PR changes "docker login" tasks from using `shell` to using `docker_login`.

-------
**README.md**: 
* Add `python3-docker` to dnf/yum install
* Add `registry.redhat.io` to `docker login` example

-------
**roles/olm_disconnected/tasks/main.yml**:
* `shell` -> `docker_login` 