### PR TITLE
Automatically add image registry to insecure-registries for 'docker/daemon.json' case

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,0 +1,3 @@
+insecure_registry_string: ""
+docker_dir: "/etc/docker"
+daemon_json: "daemon.json"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,0 +1,69 @@
+#PARTIAL: https://github.com/jmontleon/restricted-network-operator-mirror/issues/2
+- name: "Confirm {{ docker_dir }} exists"
+  stat:
+    path: "{{ docker_dir }}"
+  register: docker_dir_check
+
+- when:
+  - docker_dir_check.stat.exists and docker_dir_check.stat.isdir
+
+  block:
+
+  - name: "Look for an existing {{ daemon_json }} file"
+    stat:
+      path: "{{ docker_dir }}/{{ daemon_json }}"
+    register: daemon_json_check
+
+  - name: "Import {{ daemon_json }} content"
+    include_vars:
+      file: "{{ docker_dir }}/{{ daemon_json }}"
+      name: docker_daemon_json
+    when: daemon_json_check.stat.exists and daemon_json_check.stat.isreg
+
+  - name: "Validate insecure-registries list"
+    set_fact:
+      docker_daemon_json: "{{ docker_daemon_json | combine({'insecure-registries':[]}) }}"
+    when: not docker_daemon_json['insecure-registries'] is defined
+
+  - name: "Create string from insecure-registries list"
+    set_fact:
+      insecure_registry_string: "{{ insecure_registry_string }}{{ (index > 0)|ternary(',','') }}{{ item }}"
+    loop: "{{ ( docker_daemon_json | default({'insecure-registries':[]}) ) | json_query('\"insecure-registries\"[]')  }}"
+    loop_control:
+      index_var: index
+
+  - when:
+    - not registry_route.stdout in insecure_registry_string
+
+    block:
+
+    - name: "Add {{ registry_route.stdout }} to insecure-registries list"
+      set_fact:
+        new_insreg_list: "{{ ( docker_daemon_json | default({'insecure-registries':[]}) ) | json_query('\"insecure-registries\"[]') + [ registry_route.stdout ] }}"
+  
+    - name: "Clean insecure-registries list"
+      set_fact:
+        new_insreg_list: "{{ new_insreg_list | unique }}"
+  
+    - name: "Create sanitized insecure-registries list"
+      set_fact:
+        new_insreg: |
+          {
+            "insecure-registries" :  {{ new_insreg_list }}
+          }
+  
+    - name: "Generate updated {{ daemon_json }} contents"
+      set_fact:
+        new_daemon_json: "{{ docker_daemon_json  | combine(new_insreg) }}"
+  
+    - name: "Write {{ daemon_json }} file"
+      copy:
+        content:  "{{ new_daemon_json | to_nice_json }}"
+        dest: "{{ docker_dir }}/{{ daemon_json }}"
+      backup: true
+  
+    - name: "Restart docker service"
+      service:
+        name: docker
+        state: restarted
+  

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -60,7 +60,7 @@
       copy:
         content:  "{{ new_daemon_json | to_nice_json }}"
         dest: "{{ docker_dir }}/{{ daemon_json }}"
-      backup: true
+        backup: true
   
     - name: "Restart docker service"
       service:

--- a/roles/olm_disconnected/tasks/main.yml
+++ b/roles/olm_disconnected/tasks/main.yml
@@ -57,9 +57,17 @@
         password: "{{ registry_sa_token.stdout }}"
         registry: "{{ registry_route.stdout }}"
     rescue:
+    - name: "Include insecure-registries fix-up role"
+      include_role:
+        name: docker
+    - name: Docker login to internal OpenShift registry
+      docker_login:
+        username: registry
+        password: "{{ registry_sa_token.stdout }}"
+        registry: "{{ registry_route.stdout }}"
+    rescue:
     - pause:
-        prompt: Add {{ registry_route.stdout }} to your insecure regisries, restart docker, then press return to try again
-
+        prompt: Add {{ registry_route.stdout }} to your insecure registries, restart docker, then press return to try again
     - name: Docker login to internal OpenShift registry
       docker_login:
         username: registry

--- a/roles/olm_disconnected/tasks/main.yml
+++ b/roles/olm_disconnected/tasks/main.yml
@@ -60,6 +60,8 @@
     - name: "Include insecure-registries fix-up role"
       include_role:
         name: docker
+
+  - block:
     - name: Docker login to internal OpenShift registry
       docker_login:
         username: registry


### PR DESCRIPTION
This PR addresses the 'docker/daemon.json' case of https://github.com/jmontleon/restricted-network-operator-mirror/issues/2 with fall-through to `pause:` for manual intervention to configure image registry in insecure-registries automatically.

-------
**roles/olm_disconnected/tasks/main.yml**:
* Add `include_role:` for docker insecure-registries automated fix-up attempt to `block:`
* Split `block:` to keep `pause:` if automated addition fails

-------
**roles/docker/tasks/main.yml**:
* Read existing content from file, if found
* Cover scenarios for `docker/daemon.json`
  * File doesn't exist
  * File exists without existing _insecure-registries_ content
  * File exists with existing _insecure-registries_ content
  * ...
* Preserve existing content while adding image registry to _insecure-registries_ before writing new file and restarting docker service

-------
**roles/docker/defaults/main.yml**:
* Set variable defaults for required variables

